### PR TITLE
Check for existence of the "sys_dist" ets table

### DIFF
--- a/src/riak_sysmon_filter.erl
+++ b/src/riak_sysmon_filter.erl
@@ -359,9 +359,14 @@ get_node_map() ->
                 end
          end || T <- ets:tab2list(sys_dist)]
     catch X:Y ->
-            error_logger:error_msg("~s:get_node_map: ~p ~p @ ~p\n",
-                                   [?MODULE, X, Y, erlang:get_stacktrace()]),
-            []
+            case ets:info(sys_dist, name) of
+                undefined ->
+                    [];
+                sys_dist ->
+                    error_logger:error_msg("~s:get_node_map: ~p ~p @ ~p\n",
+                                           [?MODULE, X, Y, erlang:get_stacktrace()]),
+                    []
+            end
     end.
 
 -ifdef(TEST).


### PR DESCRIPTION
To avoid false error log events for a non-distributed node, it is
necessary to check the existence of the "sys_dist" ets table before
calling tab2list.
