### PR TITLE
Avoid net_kernel startup/shutdown races when peeking into ETS sys_dist table

### DIFF
--- a/src/riak_sysmon_filter.erl
+++ b/src/riak_sysmon_filter.erl
@@ -357,7 +357,11 @@ get_node_map() ->
                 true ->
                      {bummer, bummer}
                 end
-         end || T <- ets:tab2list(sys_dist)]
+         end || T <- try
+                         ets:tab2list(sys_dist)
+                     catch _:_ ->
+                             []
+                     end]
     catch X:Y ->
             error_logger:error_msg("~s:get_node_map: ~p ~p @ ~p\n",
                                    [?MODULE, X, Y, erlang:get_stacktrace()]),


### PR DESCRIPTION
Avoid errors like this:

```
2013-08-08 14:55:26.301 [error] <0.7207.0> riak_sysmon_filter:get_node_map: error badarg @ [{ets,match_object,[sys_dist,'_'],[]},{ets,tab2list,1,[{file,"ets.erl"},{line,323}]},{riak_sysmon_filter,get_node_map,0,[{file,"src/riak_sysmon_filter.erl"},{line,360}]},{riak_sysmon_filter,handle_info,2,[{file,"src/riak_sysmon_filter.erl"},{line,249}]},{gen_server,handle_msg,5,[{file,"gen_server.erl"},{line,607}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,227}]}]
```
