### PR TITLE
Support OTP release 18.x long_schedules

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,9 @@
 {erl_opts, [debug_info,
             fail_on_warning,
             {platform_define, "^[0-9]+", namespaced_types},
-            {platform_define, "R16B01|R16B02|17", long_schedule},
+            {platform_define, "R16B01|R16B02|R16B03|R16B03-117|18", long_schedule},
             {parse_transform, lager_transform}]}.
+
 {eunit_opts, [verbose]}.
 {deps, [
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}


### PR DESCRIPTION
This PR should be fairly easy to add. I've cut it down to this thing only, as it is currently what would be of interest to the Basho community I think. The other parts I have is a layering of rebar3 on top of `riak_sysmon`, but I think you better wait until you start that move for real: there are simply too many small things that has to be sorted out in your end before that can happen, and I don't know enough about your infrastructure, test setup, and so on.

OTP Release 18 supports long GC schedules, like releases 16 and 17. Add
the needed configuration to rebar.config to tell the toolchain that it can
set the correct define-macro.
