### PR TITLE
Updated cuttlefish dependency so it compiles on Erlang 18.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
 
 {eunit_opts, [verbose]}.
 {deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.


### PR DESCRIPTION
Issue here: https://github.com/basho/riak_sysmon/issues/21
