### PR TITLE
Upgrade cuttlefish to 2.0.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
             {parse_transform, lager_transform}]}.
 {eunit_opts, [verbose]}.
 {deps, [
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.3"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.5"}}}
        ]}.


### PR DESCRIPTION
This is required to update lager to 2.2.0
